### PR TITLE
Fix for tag highlights

### DIFF
--- a/Pawn.tmLanguage
+++ b/Pawn.tmLanguage
@@ -62,7 +62,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b([A-Za-z0-9]+)\:.\b</string>
+			<string>\b([A-Za-z0-9]+)\:\s*\b</string>
 			<key>name</key>
 			<string>storage.modifier.c</string>
 		</dict>


### PR DESCRIPTION
In 7c6bb0ed29f32250404baf9a411b873c1d0ef487 you fix tags with whitespace, but broke tags with a single-character variable.