### PR TITLE
Updated/Fixed (000_000 - working, 0b0000 - working). Added #emit pre-processor directive.

### DIFF
--- a/Pawn.tmLanguage
+++ b/Pawn.tmLanguage
@@ -98,7 +98,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))?)?\b</string>
+			<string>\b((0(x|X)[0-9a-fA-F\_]*)|(0(b|B)[0-1\_]*)|(([0-9\_]+\.?[0-9\_]*)|(\.[0-9\_]+))?)?\b</string>
 			<key>name</key>
 			<string>constant.numeric.c</string>
 		</dict>
@@ -167,6 +167,41 @@
 					<string>#string_escaped_char</string>
 				</dict>
 			</array>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?x)
+				^\s*(\#|@)\s*(emit) #pre-processor directive
+				(\s+
+					([A-Z0-9a-z]+)
+					((\.)
+					([A-Za-z]+)
+					)?
+				|\s*)
+			</string>
+			<key>captures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.import.c</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.preprocessor.c</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.parameters.c</string>
+				</dict>
+				<key>7</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.preprocessor.c</string>
+				</dict>
+			</dict>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
_ - "separator" working in the Pawn.
0000_00_0000_000_00_000_00000_

0b00000000000000000000 - it's working too :smile: 