### PR TITLE
Fixes for #48 (comment)

### DIFF
--- a/Pawn.tmLanguage
+++ b/Pawn.tmLanguage
@@ -1211,7 +1211,7 @@
 				</dict>
 				<dict>
 					<key>match</key> <string>(?ix)
-						(?&lt;!\.) \b
+						\b
 
 						[0-9][0-9_]*
 
@@ -1221,7 +1221,7 @@
 						# the remainder (after invalid chars, if any) and a type
 						[0-9]* (u?l{0,2}|lul?|llu)
 
-						\b (?!\.)
+						\b
 					</string>
 					<key>name</key> <string>constant.numeric.integer.decimal.c</string>
 					<key>captures</key>

--- a/Pawn.tmLanguage
+++ b/Pawn.tmLanguage
@@ -859,19 +859,11 @@
 			<key>patterns</key>
 			<array>
 				<dict> <key>include</key> <string>#comments</string> </dict>
-				<dict> <key>include</key> <string>#lex-access</string> </dict>
 				<dict> <key>include</key> <string>#lex-continuation</string> </dict>
 				<dict> <key>include</key> <string>#lex-newline</string> </dict>
 				<dict> <key>include</key> <string>#lex-number</string> </dict>
 				<dict> <key>include</key> <string>#lex-string</string> </dict>
 			</array>
-		</dict>
-		<key>lex-access</key>
-		<dict>
-			<key>match</key>
-			<string>(?:(?&lt;=\.)|(?&lt;=-&gt;))\b([a-zA-Z_]\w*+)\b(?!(?:\s|/\*.*?\*/)*+\()</string>
-			<key>name</key>
-			<string>variable.other.dot-access.c</string>
 		</dict>
 		<key>lex-continuation</key>
 		<dict>

--- a/Pawn.tmLanguage
+++ b/Pawn.tmLanguage
@@ -949,13 +949,6 @@
 					</dict>
 				</dict>
 				<dict>
-					<key>match</key> <string>\s*\b(public|forward|native|char|const|static|stock)\b</string>
-					<key>captures</key>
-					<dict>
-						<key>1</key> <dict> <key>name</key> <string>storage.modifier.c</string> </dict>
-					</dict>
-				</dict>
-				<dict>
 					<key>match</key>
 					<string>^(?!case.*)\s*\b([A-Za-z_]\w*)\:\s*\b</string>
 					<key>name</key>


### PR DESCRIPTION
https://github.com/Southclaw/pawn-sublime-language/issues/48#issuecomment-213499262
- Remove duplicate code
- Fix numerical range for switch/case construction (http://prntscr.com/avi6s8)
- Removed dot-access construction (fix this: 
![screenshot from 2016-04-25 12-54-46](https://cloud.githubusercontent.com/assets/1020099/14780305/0a15cdb8-0ae5-11e6-83cc-b6de20ff532d.png))