### PR TITLE
Completely fixed tags

### DIFF
--- a/Pawn.tmLanguage
+++ b/Pawn.tmLanguage
@@ -201,7 +201,7 @@
 				    (?&lt;= \w ) \s
 
 				  | #  or type modifier / closing bracket before name
-				    (?&lt;= [^&amp;]&amp; | [*&gt;)}\]] ) ) \s*
+				    (?&lt;= [^&amp;]&amp; | [*&gt;)}\]\:] ) ) \s*
 
 				(   (?: [A-Za-z_]\w*+ | ::[^:] )++
 				    (?: (?&lt;= ^ operator | \W operator )  # C++ operator?
@@ -912,6 +912,22 @@
 					</dict>
 				</dict>
 				<dict>
+					<key>begin</key> <string>^\s*(case)\s+</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key> <dict> <key>name</key> <string>keyword.control.c</string> </dict>
+					</dict>
+					<key>end</key> <string>(:)|(?&lt;=^|[^\\])\s*(\n)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key> <dict> <key>name</key> <string>keyword.operator.ternary.c</string> </dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict> <key>include</key> <string>#lex-core</string> </dict>
+					</array>
+				</dict>
+				<dict>
 					<key>match</key> <string>\s*\b(assert|break|case|continue|default|do|else|exit|for|goto|if|return|sleep|state|switch|while)\b</string>
 					<key>captures</key>
 					<dict>
@@ -934,15 +950,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>case\s*(([a-zA-Z_@0-9])*([\s,\.]))*(([a-zA-Z_@0-9])*\:)</string>
-					<key>captures</key>
-					<dict>
-						<key>1</key> <dict> <key>name</key> <string>storage.type.c</string> </dict>
-					</dict>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>^(?!case.*)\s*\b([A-Za-z_]\w*)\:\s*\b</string>
+					<string>([A-Za-z_]\w*)\:</string>
 					<key>name</key>
 					<string>storage.modifier.c</string>
 				</dict>

--- a/misc/syntax_test-1
+++ b/misc/syntax_test-1
@@ -53,6 +53,23 @@ ptask testFunction()
     Dialog_ShowCallback(playerid, using inline, (range..range), elipsis_va_args, ...);
 }
 
+Tag:testFunction(Tag:testParam, Tag:testParam)
+{
+
+}
+
+stock Tag:testFunction(Tag:testParam, Tag:testParam)
+{
+    new Tag:var,
+        Tag:var;
+
+    switch (var) {
+        case VAR: 
+        case VAR: return 0;
+        case VAR1, 1..3, 454, VAR2: return 0;
+    }
+}
+
 #if HOLIDAY_CHRISTMAS == (true) || HOLIDAY_HALLOWEEN == (true) || HOLIDAY_EASTER == (true)
 //^source.pawn meta.preprocessor.directive.c keyword.other.preprocessor.c
 #define MAX_HOLIDAY_PICKUPS 250


### PR DESCRIPTION
Fix #48
- Fixed highlighting for function with tag
- Fixed tag highlighting for strings that contain non-space symbols before the tag

# Before
![screenshot from 2016-04-25 19-20-43](https://cloud.githubusercontent.com/assets/1020099/14790664/dd60bf72-0b1a-11e6-80d0-ad65ea1e0d3e.png)
# After
![screenshot from 2016-04-25 19-19-57](https://cloud.githubusercontent.com/assets/1020099/14790639/c16e0e3c-0b1a-11e6-8008-1434d86a6df7.png)